### PR TITLE
Only intercept .jade files

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(jadeOptions) {
     var protocol = require('protocol');
     var options = extend({}, jadeOptions || {});
 
-    protocol.interceptProtocol('file', function(request, callback) {
+    protocol.interceptProtocol('file', function(request) {
         if(request) {
           var file = request.url.substr(8);
           if(file.endsWith('.jade')) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require('path');
 var jade = require('jade');
 var extend = require('util')._extend;
 
-module.exports = function(jadeOptions) {
+module.exports = function(jadeOptions, locals) {
   app.on('ready', function() {
     var protocol = require('protocol');
     var options = extend({}, jadeOptions || {});
@@ -12,7 +12,7 @@ module.exports = function(jadeOptions) {
         if(request) {
           var file = request.url.substr(8);
           if(file.endsWith('.jade')) {
-            var compiled = jade.compileFile(file, jadeOptions)();
+            var compiled = jade.compileFile(file, jadeOptions)(locals);
 
             return new protocol.RequestStringJob({
               mimeType: 'text/html',

--- a/index.js
+++ b/index.js
@@ -1,47 +1,29 @@
 var app = require('app');
-var fs = require('fs');
 var path = require('path');
 var jade = require('jade');
 var extend = require('util')._extend;
 
-module.exports = function(jadeOptions, locals) {
+module.exports = function(jadeOptions) {
   app.on('ready', function() {
     var protocol = require('protocol');
     var options = extend({}, jadeOptions || {});
 
-    protocol.interceptBufferProtocol('file', function(request, callback) {
-      var file = request.url.substr(7);
-      var content = null;
+    protocol.interceptProtocol('file', function(request, callback) {
+        if(request) {
+          var file = request.url.substr(8);
+          if(file.endsWith('.jade')) {
+            var compiled = jade.compileFile(file, jadeOptions)();
 
-      // See if file actually exists
-      try {
-        content = fs.readFileSync(file, 'utf8');
-      } catch (e) {
-        // See here for error numbers:
-        // https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
-       if (e.code === 'ENOENT') {
-         // NET_ERROR(FILE_NOT_FOUND, -6)
-         callback(6);
-       }
-
-       // All other possible errors return a generic failure
-       // NET_ERROR(FAILED, -2)
-       callback(2);
-      }
-
-      if (path.extname(file) === '.jade') {
-        var compiled = jade.compileFile(file, jadeOptions)(locals);
-
-        callback({data: new Buffer(compiled), mimeType:'text/html'});
-      } else {
-        callback({data: new Buffer(content)});
-      }
-    }, function (error, scheme) {
-      if (!error) {
-        console.log('jade interceptor registered successfully');
-      } else {
-        console.error('Jade interceptor failed:', error);
-      }
+            return new protocol.RequestStringJob({
+              mimeType: 'text/html',
+              data: compiled
+            });
+          } else {
+            return null;
+          }
+        }
+    }, function() {
+        console.log("jade active")
     });
   });
 };


### PR DESCRIPTION
Hey, your new code was intercepting all the calls(protocols?). I adjusted it so it only intercepts .jade files. This seems to be working fine for my project, please do test it out yourself.

The updated solution you had on npm broke the default protocol for some reason, which replaced every protocol with the jade protocol.

EDIT
Should mention that it breaks the files that are included within the jade file.
