### PR TITLE
Output error so we get better feedback

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = function(jadeOptions, locals) {
           return callback({data: content, mimeType: mime.lookup(ext)});
         }
       } catch (e) {
+       console.error(e);  
         // See here for error numbers:
         // https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
        if (e.code === 'ENOENT') {


### PR DESCRIPTION
If jade file has a syntax error its not shown out. We only get a error on the console "Not allowed to load local resource: ". This way the the error is printed in the main process's stderr.
